### PR TITLE
Fix new strategy spec fo Sidekiq Pro

### DIFF
--- a/spec/lib/sidekiq/throttled/strategy_spec.rb
+++ b/spec/lib/sidekiq/throttled/strategy_spec.rb
@@ -586,7 +586,7 @@ RSpec.describe Sidekiq::Throttled::Strategy do
 
           expect do
             subject.requeue_throttled(work)
-          end.to raise_error(RuntimeError, "unrecognized :with option #{with_proc}")
+          end.to raise_error(RuntimeError, "unrecognized :with option invalid_value")
         end
       end
 


### PR DESCRIPTION
Spec coverage is

```json
{
  "result": {
    "line": 99.37,
    "branch": 89.87
  }
}
```