### PR TITLE
Adjust queue name handling in re_enqueue_throttled and reschedule_throttled methods

### DIFF
--- a/spec/lib/sidekiq/throttled/strategy_spec.rb
+++ b/spec/lib/sidekiq/throttled/strategy_spec.rb
@@ -666,7 +666,17 @@ RSpec.describe Sidekiq::Throttled::Strategy do
           it "returns false and does not reschedule the job" do
             expect(Sidekiq::Client).not_to receive(:enqueue_to_in)
             expect(work).not_to receive(:acknowledge)
-            expect(subject.send(:reschedule_throttled, work, requeue_to: "default")).to be_falsey
+            expect(subject.send(:reschedule_throttled, work, "queue:default")).to be_falsey
+          end
+        end
+
+        context "when target_queue has the 'queue:' prefix" do
+          let(:target_queue) { "queue:default" }
+
+          it "reschedules the job to the specified queue" do
+            expect(Sidekiq::Client).to receive(:enqueue_to_in).with("default", anything, anything, anything)
+            expect(work).to receive(:acknowledge)
+            subject.send(:reschedule_throttled, work, target_queue)
           end
         end
       end
@@ -998,7 +1008,17 @@ RSpec.describe Sidekiq::Throttled::Strategy do
           it "returns false and does not reschedule the job" do
             expect(Sidekiq::Client).not_to receive(:enqueue_to_in)
             expect(work).not_to receive(:acknowledge)
-            expect(subject.send(:reschedule_throttled, work, requeue_to: "default")).to be_falsey
+            expect(subject.send(:reschedule_throttled, work, "queue:default")).to be_falsey
+          end
+        end
+
+        context "when target_queue has the 'queue:' prefix" do
+          let(:target_queue) { "queue:default" }
+
+          it "reschedules the job to the specified queue" do
+            expect(Sidekiq::Client).to receive(:enqueue_to_in).with("default", anything, anything, anything)
+            expect(work).to receive(:acknowledge)
+            subject.send(:reschedule_throttled, work, target_queue)
           end
         end
       end


### PR DESCRIPTION
Instead of potentially adding and removing the prefix, I think we can agree that `re_enqueue_throttled` should add the prefix if it's not present, while `reschedule_throttled` should drop the prefix if it is